### PR TITLE
Update DMRScan_vignette.Rmd YAML to not use leading spaces

### DIFF
--- a/vignettes/DMRScan_vignette.Rmd
+++ b/vignettes/DMRScan_vignette.Rmd
@@ -1,13 +1,13 @@
 ---
-  title: "Using the DMR Scan Package"
-  author: "Christian M Page"
-  package: DMRScan
-  output: 
-    BiocStyle::html_document
-  vignette: >
-    %\VignetteIndexEntry{DMR Scan Vignette}
-    %\VignetteEngine{knitr::rmarkdown}
-    %\VignetteEncoding{UTF-8}  
+title: "Using the DMR Scan Package"
+author: "Christian M Page"
+package: DMRScan
+output: 
+  BiocStyle::html_document
+vignette: >
+  %\VignetteIndexEntry{DMR Scan Vignette}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}  
 ---
 
 # Abstract


### PR DESCRIPTION
YAML is space sensitive and this was leading to the following error:

```
* creating vignettes ... ERROR
--- re-building ‘DMRScan_vignette.Rmd’ using rmarkdown
YAML parse exception at line 10, column 0:
did not find expected <document start>
Error: processing vignette 'DMRScan_vignette.Rmd' failed with diagnostics:
pandoc document conversion failed with error 64
--- failed re-building ‘DMRScan_vignette.Rmd’
```

I am not sure why the error happens only on the Linux [aarch64 ](https://bioconductor.org/checkResults/3.18/bioc-LATEST/DMRScan/kunpeng2-buildsrc.html) builder.